### PR TITLE
Updated SP-PH-App samples to fix NuGet package reference

### DIFF
--- a/O3651-3 Getting started with Apps for SharePoint/Completed Projects/MyFirstCloudHostedApp/MyFirstCloudHostedAppWeb/Web.config
+++ b/O3651-3 Getting started with Apps for SharePoint/Completed Projects/MyFirstCloudHostedApp/MyFirstCloudHostedAppWeb/Web.config
@@ -10,7 +10,7 @@
   </system.web>
   <appSettings>
     <add key="ClientId" value="" />
-    <add key="ClientSecret" value="OxTnhFOx1JRbVB9E521jBqM+VhmbUdV++FqPXKOjI+o=" />
+    <add key="ClientSecret" value="" />
   </appSettings>
   <system.serviceModel>
     <bindings>

--- a/O3651-3 Getting started with Apps for SharePoint/Completed Projects/MyFirstCloudHostedApp/MyFirstCloudHostedAppWeb/packages.config
+++ b/O3651-3 Getting started with Apps for SharePoint/Completed Projects/MyFirstCloudHostedApp/MyFirstCloudHostedAppWeb/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
 </packages>

--- a/O3651-7 Setting up your Developer environment in Office 365/Completed Projects/Exercise_02/AzureCloudAppWeb/packages.config
+++ b/O3651-7 Setting up your Developer environment in Office 365/Completed Projects/Exercise_02/AzureCloudAppWeb/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />

--- a/O3651-7 Setting up your Developer environment in Office 365/Completed Projects/Exercise_03/AzureCloudAppWeb/packages.config
+++ b/O3651-7 Setting up your Developer environment in Office 365/Completed Projects/Exercise_03/AzureCloudAppWeb/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />

--- a/O3652-7 Deep Dive into Security and OAuth/Completed Projects/Exercise01/ProviderHostedOAuth/ProviderHostedOAuthWeb/Web.config
+++ b/O3652-7 Deep Dive into Security and OAuth/Completed Projects/Exercise01/ProviderHostedOAuth/ProviderHostedOAuthWeb/Web.config
@@ -9,8 +9,8 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="ClientId" value="ec84d124-1b40-4f81-b03b-965365f669f6" />
-    <add key="ClientSecret" value="m+4ksJnaHzFkVe/IVcrlj0Y5hY5krnOm0MMP/1F59AM=" />
+    <add key="ClientId" value="" />
+    <add key="ClientSecret" value="" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5" />

--- a/O3652-7 Deep Dive into Security and OAuth/Completed Projects/Exercise01/ProviderHostedOAuth/ProviderHostedOAuthWeb/packages.config
+++ b/O3652-7 Deep Dive into Security and OAuth/Completed Projects/Exercise01/ProviderHostedOAuth/ProviderHostedOAuthWeb/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />

--- a/O3652-8 App Lifecycle Management/Completed Projects/Lifecycle App Project/LifecycleApp/LifecycleAppWeb/packages.config
+++ b/O3652-8 App Lifecycle Management/Completed Projects/Lifecycle App Project/LifecycleApp/LifecycleAppWeb/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />


### PR DESCRIPTION
Updated all NuGet package references where **AppForSharePoint16WebToolkit** was present in the `packages.config` files to use the correct [AppForSharePointWebToolkit](http://www.nuget.org/packages/AppForSharePointWebToolkit) NuGet package reference instead. The incorrect references is added by the Office Dev Tools from a locally cached copy of the *AppForSharePoint16WebToolkit* package that does not exist in the public [NuGet Package registry](http://www.nuget.org/packages). This causes an issue when cloning the project from source control and doing a local "NuGet Package Restore".

Also cleared our any values for the **ClientID** or **ClientSecret** in the `web.config` files.