### PR TITLE
Updated O365 API samples to fix NuGet package reference

### DIFF
--- a/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Completed Solutions/Office365Contacts.csproj
+++ b/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Completed Solutions/Office365Contacts.csproj
@@ -49,7 +49,7 @@
       <HintPath>packages\EntityFramework.6.1.1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient">
-      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.22\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.2\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -81,12 +81,6 @@
     </Reference>
     <Reference Include="Microsoft.OData.Edm">
       <HintPath>packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.Discovery">
-      <HintPath>packages\Microsoft.Office365.Discovery.1.0.22\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.OutlookServices">
-      <HintPath>packages\Microsoft.Office365.OutlookServices.1.0.22\lib\net40\Microsoft.Office365.OutlookServices.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Completed Solutions/packages.config
+++ b/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Completed Solutions/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
-  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />

--- a/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Demos/OutlookServicesClientDemo/OutlookServicesClientDemo.csproj
+++ b/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Demos/OutlookServicesClientDemo/OutlookServicesClientDemo.csproj
@@ -46,7 +46,7 @@
       <HintPath>packages\EntityFramework.6.1.1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient">
-      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.22\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.2\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -78,18 +78,6 @@
     </Reference>
     <Reference Include="Microsoft.OData.Edm">
       <HintPath>packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.Discovery">
-      <HintPath>packages\Microsoft.Office365.Discovery.1.0.21\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.OAuth">
-      <HintPath>packages\Microsoft.Office365.OAuth.AspNet.1.0.21\lib\net45\Microsoft.Office365.OAuth.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.OAuth.Web">
-      <HintPath>packages\Microsoft.Office365.OAuth.AspNet.1.0.21\lib\net45\Microsoft.Office365.OAuth.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.OutlookServices">
-      <HintPath>packages\Microsoft.Office365.OutlookServices.1.0.21\lib\net40\Microsoft.Office365.OutlookServices.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Demos/OutlookServicesClientDemo/README.md
+++ b/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Demos/OutlookServicesClientDemo/README.md
@@ -1,0 +1,18 @@
+To run this project, you must perform the following steps:
+
+## Create Azure AD Application
+Create an Azure AD application in your Azure tenant. Make sure you obtain the app's **ClientID**, **Client Secret** (aka: key) & the ID of your Azure AD tenant.
+
+## Update Project's Web.Config
+Open the project's `web.config` file and set the values for the **ClientID**, **Password** (aka the Azure AD app's secret / key) & **TenantId** using the values from the previously created Azure AD app.
+
+## Run NuGet Package Restore
+Download all the referenced packages in the project by running NuGet's package restore. This can be done using the **Package Manager Console** tool window in Visual Studio and clicking the button **Restore** found in the top-right corner of the tool window.
+
+## Add Office 365 as a Connected Service
+Add Office 365 as a Connected Service to the project using the wizard: **Add => Connected Service**. This will find the ClientID in the project's `web.config`. You need to add the necessary permissions required for this project in the dialog. 
+
+Once clicking **OK** in the wizard, it will add all the necessary NuGet packages & add the necessary references to the project.
+
+## Test by Building the Project
+Finally, build the project to test that all references are correct.

--- a/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Demos/OutlookServicesClientDemo/packages.config
+++ b/O3653-2 Deep Dive into Office 365 APIs for Calendar, Mail, and Contacts/Demos/OutlookServicesClientDemo/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />

--- a/O3653-3 Deep Dive into Office 365 APIs for OneDrive for Business/Completed Projects/OneDriveWeb.csproj
+++ b/O3653-3 Deep Dive into Office 365 APIs for OneDrive for Business/Completed Projects/OneDriveWeb.csproj
@@ -51,7 +51,7 @@
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient, Version=1.0.7.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.22\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.2\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -86,14 +86,6 @@
     </Reference>
     <Reference Include="Microsoft.OData.Edm">
       <HintPath>..\packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.Discovery, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Office365.Discovery.1.0.22\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.SharePoint, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Office365.SharePoint.1.0.22\lib\net40\Microsoft.Office365.SharePoint.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/O3653-3 Deep Dive into Office 365 APIs for OneDrive for Business/Completed Projects/packages.config
+++ b/O3653-3 Deep Dive into Office 365 APIs for OneDrive for Business/Completed Projects/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
-  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Completed Projects/README.md
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Completed Projects/README.md
@@ -1,0 +1,18 @@
+To run this project, you must perform the following steps:
+
+## Create Azure AD Application
+Create an Azure AD application in your Azure tenant. Make sure you obtain the app's **ClientID**, **Client Secret** (aka: key) & the ID of your Azure AD tenant.
+
+## Update Project's Web.Config
+Open the project's `web.config` file and set the values for the **ClientID**, **Password** (aka the Azure AD app's secret / key) & **TenantId** using the values from the previously created Azure AD app.
+
+## Run NuGet Package Restore
+Download all the referenced packages in the project by running NuGet's package restore. This can be done using the **Package Manager Console** tool window in Visual Studio and clicking the button **Restore** found in the top-right corner of the tool window.
+
+## Add Office 365 as a Connected Service
+Add Office 365 as a Connected Service to the project using the wizard: **Add => Connected Service**. This will find the ClientID in the project's `web.config`. You need to add the necessary permissions required for this project in the dialog. 
+
+Once clicking **OK** in the wizard, it will add all the necessary NuGet packages & add the necessary references to the project.
+
+## Test by Building the Project
+Finally, build the project to test that all references are correct.

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Completed Projects/TasksWeb/TasksWeb.csproj
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Completed Projects/TasksWeb/TasksWeb.csproj
@@ -46,7 +46,7 @@
       <HintPath>..\packages\EntityFramework.6.1.1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient">
-      <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.22\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.2\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -78,12 +78,6 @@
     </Reference>
     <Reference Include="Microsoft.OData.Edm">
       <HintPath>..\packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.Discovery">
-      <HintPath>..\packages\Microsoft.Office365.Discovery.1.0.22\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.SharePoint">
-      <HintPath>..\packages\Microsoft.Office365.SharePoint.1.0.22\lib\net40\Microsoft.Office365.SharePoint.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Completed Projects/TasksWeb/packages.config
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Completed Projects/TasksWeb/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
-  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/OneDriveWeb/OneDriveWeb.csproj
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/OneDriveWeb/OneDriveWeb.csproj
@@ -51,20 +51,20 @@
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient, Version=1.0.7.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.22\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.2\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>packages\Microsoft.Data.Edm.5.6.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.OData, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>packages\Microsoft.Data.OData.5.6.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>packages\Microsoft.Data.Services.Client.5.6.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -79,46 +79,38 @@
       <HintPath>packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.1\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.OData.Client">
-      <HintPath>..\packages\Microsoft.OData.Client.6.8.1\lib\net40\Microsoft.OData.Client.dll</HintPath>
+      <HintPath>packages\Microsoft.OData.Client.6.8.1\lib\net40\Microsoft.OData.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.OData.Core">
-      <HintPath>..\packages\Microsoft.OData.Core.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+      <HintPath>packages\Microsoft.OData.Core.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.OData.Edm">
-      <HintPath>..\packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.Discovery, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Office365.Discovery.1.0.22\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.SharePoint, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Office365.SharePoint.1.0.22\lib\net40\Microsoft.Office365.SharePoint.dll</HintPath>
+      <HintPath>packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
-      <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Host.SystemWeb">
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.0.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+      <HintPath>packages\Microsoft.Owin.Host.SystemWeb.3.0.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security">
-      <HintPath>..\packages\Microsoft.Owin.Security.3.0.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+      <HintPath>packages\Microsoft.Owin.Security.3.0.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security.Cookies">
-      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.3.0.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+      <HintPath>packages\Microsoft.Owin.Security.Cookies.3.0.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security.OpenIdConnect">
-      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.3.0.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
+      <HintPath>packages\Microsoft.Owin.Security.OpenIdConnect.3.0.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Spatial">
-      <HintPath>..\packages\Microsoft.Spatial.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+      <HintPath>packages\Microsoft.Spatial.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <HintPath>packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -131,7 +123,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Spatial, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Spatial.5.6.3\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>packages\System.Spatial.5.6.3\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -174,14 +166,14 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
     <Reference Include="System.Web.Optimization">
-      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/OneDriveWeb/packages.config
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/OneDriveWeb/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
-  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/SPContactsList/README.md
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/SPContactsList/README.md
@@ -1,0 +1,18 @@
+To run this project, you must perform the following steps:
+
+## Create Azure AD Application
+Create an Azure AD application in your Azure tenant. Make sure you obtain the app's **ClientID**, **Client Secret** (aka: key) & the ID of your Azure AD tenant.
+
+## Update Project's Web.Config
+Open the project's `web.config` file and set the values for the **ClientID**, **Password** (aka the Azure AD app's secret / key) & **TenantId** using the values from the previously created Azure AD app.
+
+## Run NuGet Package Restore
+Download all the referenced packages in the project by running NuGet's package restore. This can be done using the **Package Manager Console** tool window in Visual Studio and clicking the button **Restore** found in the top-right corner of the tool window.
+
+## Add Office 365 as a Connected Service
+Add Office 365 as a Connected Service to the project using the wizard: **Add => Connected Service**. This will find the ClientID in the project's `web.config`. You need to add the necessary permissions required for this project in the dialog. 
+
+Once clicking **OK** in the wizard, it will add all the necessary NuGet packages & add the necessary references to the project.
+
+## Test by Building the Project
+Finally, build the project to test that all references are correct.

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/SPContactsList/SPContactsList.csproj
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/SPContactsList/SPContactsList.csproj
@@ -46,7 +46,7 @@
       <HintPath>packages\EntityFramework.6.1.1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient">
-      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.22\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.2\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -78,17 +78,6 @@
     </Reference>
     <Reference Include="Microsoft.OData.Edm">
       <HintPath>packages\Microsoft.OData.Edm.6.8.1\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.Discovery, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Office365.Discovery.1.0.22\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.OutlookServices">
-      <HintPath>packages\Microsoft.Office365.OutlookServices.1.0.22\lib\net40\Microsoft.Office365.OutlookServices.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Office365.SharePoint, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.Office365.SharePoint.1.0.22\lib\net40\Microsoft.Office365.SharePoint.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -144,7 +133,7 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>
@@ -152,38 +141,38 @@
     </Reference>
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=__MvcPagesVersion__, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Optimization">
-      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.2\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.Razor.3.2.2\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>
-      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
+      <HintPath>packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
     </Reference>
     <Reference Include="Antlr3.Runtime">
       <Private>True</Private>
-      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+      <HintPath>packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/SPContactsList/packages.config
+++ b/O3653-4 Deep Dive into Office 365 APIs for SharePoint Site services/Demos/SPContactsList/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
-  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />


### PR DESCRIPTION
Updated all NuGet package references where **Microsoft.Azure.ActiveDirectory.GraphClient** was present in the `packages.config` files to use the correct [Microsoft.Azure.ActiveDirectory.GraphClient](http://www.nuget.org/packages/Microsoft.Azure.ActiveDirectory.GraphClient) NuGet package reference instead (v2.0.2). The incorrect references is added by the Office 365 API Tools from a locally cached copy of the *Microsoft.Azure.ActiveDirectory.GraphClient* package, version 1.0.22, that does not exist in the public [NuGet Package registry](http://www.nuget.org/packages). This causes an issue when cloning the project from source control and doing a local "NuGet Package Restore".

Also removed all references to the Office 365 NuGet packages

Also cleared our any values for the **ClientID** or **ClientSecret** in the `web.config` files.