### PR TITLE
update gitignore, exclude MacOS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# MacOS files
+**.DS_Store


### PR DESCRIPTION
Updated  to exclude automatically generated  hidden file in every folder when someone on MacOS opens a folder in Finder