### PR TITLE
stop console from auto closing

### DIFF
--- a/Graph/01-1 Building Graph Applications/Demos/01-console-application/README.md
+++ b/Graph/01-1 Building Graph Applications/Demos/01-console-application/README.md
@@ -291,6 +291,7 @@ Finally, update the Main method to call the `RunAsync()` method.
 static void Main(string[] args)
 {
     RunAsync().GetAwaiter().GetResult();
+    Console.ReadKey();
 }
 ````
 


### PR DESCRIPTION
Added Console.ReadKey(); in Main() so that console does not close automatically after running.