### PR TITLE
Format for valid domains is without protocol

### DIFF
--- a/Teams/02 Tabs and Connectors/Lab.md
+++ b/Teams/02 Tabs and Connectors/Lab.md
@@ -354,7 +354,7 @@ Connectors for Microsoft Teams must be registered on the [Connectors Developer D
 
     > NOTE: This field is not used by Microsoft Teams, but you must enter something.
 
-  - **Valid domains**: https://f044969c.ngrok.io
+  - **Valid domains**: f044969c.ngrok.io
 
     > NOTE: This field is used for actionable messages.
 


### PR DESCRIPTION
Uploading a `manifest.json` with a `http[s]://` type url in valid domains will fail with an error message.